### PR TITLE
DynamicModels can now be put on arbitrary layers

### DIFF
--- a/Isometric.js
+++ b/Isometric.js
@@ -161,10 +161,11 @@ exports = Class(Emitter, function (supr) {
 		this.emit('AddStaticModel', model);		
 	};
 
-	this.onAddDynamicModel = function (model) {
-		this._modelViewConnector.registerModel(model, 1);
+	this.onAddDynamicModel = function (model, layer) {
+		layer = typeof layer === 'undefined' ? 1 : layer;
+		this._modelViewConnector.registerModel(model, layer);
 
-		this.emit('AddDynamicModel', model);
+		this.emit('AddDynamicModel', model, layer);
 	};
 
 	this.onWakeupDynamicModel = function (model) {

--- a/models/item/SpawnerModel.js
+++ b/models/item/SpawnerModel.js
@@ -200,7 +200,7 @@ exports = Class(StaticModel, function (supr) {
 
 			model = new modelInfo.ctor(opts);
 			model.setSleepCB(bind(this, 'onModelSleep'));
-			this._spawnedModelCB && this._spawnedModelCB(model);
+			this._spawnedModelCB && this._spawnedModelCB(model, modelInfo.layer);
 		}
 
 		model && this._modelsAwake.push(model);


### PR DESCRIPTION
I saw that DynamicModels were always added to layer 1.  This was undesirable for what I was trying to do; I wanted more than one layer under the dynamic model.  However, I don't understand if there was a reason for it being this way in the first place, so I'll send this PR with some hesitation.

Also not sure if this is how you'd like to be able to specify the layer.  I simply added it as another parameter after the constructor object within putDynamicItem(), and again pass this layer through to the callback; somebody may have other ideas about the best way to do this.

thanks
Chris
