### PR TITLE
Allowing putDynamicItem to specify a layer

### DIFF
--- a/Isometric.js
+++ b/Isometric.js
@@ -219,7 +219,7 @@ exports = Class(Emitter, function (supr) {
 		model && this.onAddStaticModel(model);
 	};
 
-	this.putDynamicItem = function (ctor, opts) {
+	this.putDynamicItem = function (ctor, opts, layer) {
 		var model = new ctor(
 				merge(
 					opts,
@@ -229,7 +229,7 @@ exports = Class(Emitter, function (supr) {
 				)
 			);
 
-		this.onAddDynamicModel(model);
+		this.onAddDynamicModel(model, layer);
 
 		return model;
 	};


### PR DESCRIPTION
Should have been part of last PR.  Syntax is a little iffy as you have this trailing number when using putDynamicItem(), however this parameter configuration does not break backwards compatibility.
