### PR TITLE
Adds ability to specify a layer for selection

### DIFF
--- a/doc/gridSettings.md
+++ b/doc/gridSettings.md
@@ -34,7 +34,8 @@ a property for the layer.
   + `dynamicViews {number} = 0` ---Optional, the number of dynamic views on the layer.
   + `particleSystems {number} = 0` ---Optional, the number of particle systems on the layer.
   + `particleStytemSize {number} = 0` ---Optional, the number if particles in each particle system on the layer.
-  + `overDrawY {number} = 3` --Optional, the bottom-vertical overdraw for the layer.
+  + `overDrawY {number} = 3` ---Optional, the bottom-vertical overdraw for the layer.
+  + `selectionLayer {boolean}` ---Optional, designates this layer as the one on which the selection will appear.  Defaults to first layer (0).
 
 ~~~
 var gridSettings = {
@@ -55,6 +56,9 @@ var gridSettings = {
 			particleSystems: 0,
 			particleSystemSize: 0,
 			overDrawY: 3
+		},
+		{
+			selectionLayer: true
 		},
 		{
 			dynamicViews: 30,

--- a/views/GridView.js
+++ b/views/GridView.js
@@ -150,16 +150,21 @@ exports = Class([View, GridProperties], function (supr) {
 		this._layers = [];
 
 		var layers = this._gridSettings.layers;
+		// if selectionLayer is set on a layer, make GridSelection pool the child of this layer
+		var selectionLayer = 0;
 		for (var i = 0; i < layers.length; i++) {
 			var opts = merge(this.getProperties(), layers[i]);
 			opts.superview = this;
 			opts.index = i;
 			opts.tileViews = this._tileViews;
 			this._layers.push(new GridLayerView(opts));
+			if (layers[i].selectionLayer) {
+				selectionLayer = i;
+			}
 		}
 
 		this._selection = new GridSelection({
-			superview: this._layers[0],
+			superview: this._layers[selectionLayer],
 			gridView: this,
 			tileSettings: this._opts.tileSettings
 		});


### PR DESCRIPTION
I have three layers and I wanted to show a selection cursor on top of the second layer.  Because the grid selection's superview was always the first layer, if the second layer was present on a tile, it would simply not show (hidden under second layer).  This allows you, in your grid settings when defining layers, to specify a layer as the one on which the selection will appear.  My example:

``` javascript
exports = {
    tileWidth: 82,
    tileHeight: 41,
    layers: [{}, {
            selectionLayer: true
        }, {
            dynamicViews: 30
        }
    ]

};
```

The selection layer defaults to 0, as before.  As always I'm open to any ideas about syntax or variable names.  
